### PR TITLE
add query for i15-1 sample based sessions

### DIFF
--- a/conf/jobs.example.cfg
+++ b/conf/jobs.example.cfg
@@ -162,3 +162,27 @@ sql = DELETE zb
     AND (DATE(app.processingEndTime) < DATE_SUB(CURDATE(), INTERVAL 30 DAY)
       OR DATE(app.recordTimeStamp) < DATE_SUB(CURDATE(), INTERVAL 60 DAY)
     )
+
+[SampleBasedSessionsReport]
+fullname = Sample Based Sessions
+file_prefix = sample_based_sessions_report
+datasource = ispyb
+file_suffix = .csv
+sql_type = read
+sql_headers = visit,PI,start date,end date,data collections
+sql = SELECT CONCAT(proposalCode, ProposalNumber,"-",visit_number) as "{0}", 
+    familyName as "{1}",
+    BLSession.startDate as "{2}",
+    BLSession.endDate as "{3}",
+    count(*) as "{4}" 
+  FROM DataCollectionGroup 
+    LEFT JOIN DataCollection using (dataCollectionGroupId) 
+    LEFT JOIN BLSession on BLSession.sessionId = DataCollection.SESSIONID 
+    LEFT JOIN Proposal using (proposalId)
+    LEFT JOIN Person using (personId) 
+  WHERE BLSession.endDate > now() - interval 24 hour 
+    AND BLSession.endDate < now() 
+    AND visit_number is not NULL 
+    AND beamLineName = "i15-1" 
+    AND scheduled = 0 
+  GROUP BY BLSession.sessionId;


### PR DESCRIPTION
add an example query which _could_ be used to check, at 09:01 every morning, whether there were any sample based sessions on I15-1 which finished in the last 24 hours and how many data collections were performed against each.

There are no inputs so this can be executed with:

```
python bin/runreport.py -j SampleBasedSessionsReport -c /path/to/db-jobs/conf/ 
```
